### PR TITLE
Fixing support for hosted runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is a GitHub Action that uses Solid State Networks tools and services.  
 
-The action is compatible with Windows, Linux, and OSX runners.  Windows self-hosted runners require git-bash (https://git-scm.com/) in the %PATH%.
+The action is compatible with Windows, Linux, and OSX github runners, as well as Windows and OSX hosted runners.  Windows self-hosted runners require git-bash (https://git-scm.com/) in the %PATH%.
 
 ## Variables
 

--- a/action.yml
+++ b/action.yml
@@ -25,11 +25,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install system dependencies
-      if: runner.os == 'Linux' || runner.os == 'macOS'
-      shell: bash
-      run: sudo apt-get -y install p7zip-full wget
-      
     - name: Create work directory
       shell: bash
       run: |
@@ -37,31 +32,20 @@ runs:
         rm -f deploy-scripts-${{ inputs.scripts_version }}.zip
         mkdir -p solsta_work
       
-    - name: Download deploy scripts (Linux/OSX)
-      if: runner.os == 'Linux' || runner.os == 'macOS'
-      shell: bash
-      run: |
-        wget https://releases.snxd.com/deploy-scripts-${{ inputs.scripts_version }}.zip
-        7z x deploy-scripts-${{ inputs.scripts_version }}.zip
-      working-directory: solsta_work
-      
-    - name: Download deploy scripts (Windows)
-      if: runner.os == 'Windows'
-      shell: powershell
-      run: |
-        wget -o "deploy-scripts-${{ inputs.scripts_version }}.zip" https://releases.snxd.com/deploy-scripts-${{ inputs.scripts_version }}.zip
-        Expand-Archive -Force -LiteralPath "deploy-scripts-${{ inputs.scripts_version }}.zip" -DestinationPath "." 
-      working-directory: solsta_work
-      
     - name: Setup python
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
         architecture: 'x64'
         
-    - name: Create python venv
+    - name: Download deploy scripts
       shell: bash
-      run: python3 -m venv solsta_work/venv
+      run: |
+        pip install wget 
+        python -m wget -o deploy-scripts-${{ inputs.scripts_version }}.zip https://releases.snxd.com/deploy-scripts-${{ inputs.scripts_version }}.zip
+        echo -e "import zipfile\nzip = zipfile.ZipFile('deploy-scripts-${{ inputs.scripts_version }}.zip')\nzip.extractall()\n" > unzip.py
+        python unzip.py
+      working-directory: solsta_work
       
     - name: Install dotnet
       uses: actions/setup-dotnet@v2
@@ -70,7 +54,7 @@ runs:
         
     - name: Install python prerequisites
       shell: bash
-      run: python3 -m pip install -r requirements.txt
+      run: python -m pip install -r requirements.txt
       working-directory: solsta_work
       
     - name: Write console.json
@@ -94,7 +78,7 @@ runs:
       run: |
         # Download the latest SSN Console Tools if necessary
         if [ ! -d "solsta_console/${{ inputs.console_version }}" ]; then 
-          python3 direct_get.py --overwrite --version="${{ inputs.console_version }}" --target_directory=solsta_console/${{ inputs.console_version }}/ --console_credentials=client_credentials.json --component=console
+          python direct_get.py --overwrite --version="${{ inputs.console_version }}" --target_directory=solsta_console/${{ inputs.console_version }}/ --console_credentials=client_credentials.json --component=console
         fi
 
 branding:


### PR DESCRIPTION
Fixing python activation, python3->python name, and changed how the wget and unzipping happen to support hosted runners without wget or unzip.
This leads to this supporting the GitHub runners for Windows, Linux, and OSX, as well as Windows and OSX hosted runners.  Linux hosted runners have trouble installing python at all (running pip) because of openssl nonsense.